### PR TITLE
feat: add Gemini LLM provider support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,4 @@
-# LLM provider: "openai", "deepseek", or "openrouter"
+# LLM provider: "openai", "deepseek", "openrouter", or "gemini"
 LLM_PROVIDER=openrouter
 
 # OpenAI API Key
@@ -9,3 +9,6 @@ DEEPSEEK_API_KEY=your_deepseek_api_key_here
 
 # OpenRouter API Key
 OPENROUTER_API_KEY=your_openrouter_api_key_here
+
+# Google Gemini API Key
+GOOGLE_API_KEY=your_google_api_key_here

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -4,11 +4,11 @@
 
 ### Core Features (All Implemented)
 
-1. **✅ Query Clarification with OpenAI/DeepSeek**
+1. **✅ Query Clarification with Multiple LLM Providers**
    - Uses LangChain with structured output parsing
    - Pydantic models for type-safe data handling
    - Extracts key concepts, research domain, and search terms
-   - **NEW**: Supports both OpenAI and DeepSeek APIs
+   - Supports OpenAI, DeepSeek, OpenRouter, and Gemini APIs
 
 2. **✅ Google Scholar Integration**
    - Uses the `scholarly` library
@@ -36,16 +36,20 @@
 
 ### Provider Flexibility (NEW)
 
-Users can now choose between **OpenAI** or **DeepSeek** for query clarification:
+Users can now choose between **OpenAI**, **DeepSeek**, **OpenRouter**, or **Gemini** for query clarification:
 
 #### Configuration Methods
 
 **Method 1: Environment Variable (.env file)**
 ```bash
-LLM_PROVIDER=openai  # or "deepseek"
+LLM_PROVIDER=openai  # or "deepseek", "openrouter", "gemini"
 OPENAI_API_KEY=sk-...
 # or
 DEEPSEEK_API_KEY=...
+# or
+OPENROUTER_API_KEY=sk-or-...
+# or
+GOOGLE_API_KEY=...
 ```
 
 **Method 2: Programmatic**
@@ -63,6 +67,8 @@ agent = ResearchAgent(provider="deepseek")
 #### Default Models
 - **OpenAI**: `gpt-4o-mini`
 - **DeepSeek**: `deepseek-chat`
+- **OpenRouter**: `alibaba/tongyi-deepresearch-30b-a3b:free`
+- **Gemini**: `gemini-2.5-flash`
 
 Custom models can be specified via `QueryClarifier(model_name="...")`
 
@@ -163,7 +169,7 @@ All dependencies are compatible and tested:
 ### Key Improvements Made
 
 1. **✅ Fixed dependency conflict** - Updated `langchain-core` to 0.3.17
-2. **✅ Added provider flexibility** - Support for OpenAI and DeepSeek
+2. **✅ Added provider flexibility** - Support for OpenAI, DeepSeek, OpenRouter, and Gemini
 3. **✅ Comprehensive documentation** - README, QUICKSTART, PROVIDER_GUIDE
 4. **✅ Example scripts** - Multiple usage examples
 5. **✅ Type safety** - Pydantic models throughout
@@ -174,7 +180,7 @@ All dependencies are compatible and tested:
 
 The agent is production-ready with:
 - ✅ All requested features implemented
-- ✅ Flexible provider selection (OpenAI/DeepSeek)
+- ✅ Flexible provider selection (OpenAI/DeepSeek/OpenRouter/Gemini)
 - ✅ Comprehensive documentation
 - ✅ Working examples
 - ✅ REST API interface

--- a/PROVIDER_GUIDE.md
+++ b/PROVIDER_GUIDE.md
@@ -2,7 +2,7 @@
 
 ## Choosing Your LLM Provider
 
-This application supports three LLM providers for query clarification:
+This application supports four LLM providers for query clarification:
 
 ### OpenAI
 - **Model**: `gpt-4o-mini` (default)
@@ -17,11 +17,17 @@ This application supports three LLM providers for query clarification:
 - **Get API Key**: https://platform.deepseek.com/
 
 ### OpenRouter
-- **Model**: `openai/gpt-4o-mini` (default)
+- **Model**: `alibaba/tongyi-deepresearch-30b-a3b:free` (default)
 - **Pros**: Access to multiple models through one API, flexible pricing
 - **Cons**: Additional abstraction layer
 - **Get API Key**: https://openrouter.ai/keys
 - **Note**: Can access various models (OpenAI, Anthropic, Google, etc.)
+
+### Gemini
+- **Model**: `gemini-2.5-flash` (default)
+- **Pros**: Fast, cost-effective, good quality from Google
+- **Cons**: May have different capabilities than GPT models
+- **Get API Key**: https://aistudio.google.com/apikey
 
 ## Configuration
 
@@ -41,6 +47,10 @@ DEEPSEEK_API_KEY=your-key-here
 # For OpenRouter
 LLM_PROVIDER=openrouter
 OPENROUTER_API_KEY=sk-or-your-key-here
+
+# For Gemini
+LLM_PROVIDER=gemini
+GOOGLE_API_KEY=your-google-api-key-here
 ```
 
 ### Method 2: Programmatic Selection
@@ -59,6 +69,9 @@ agent = ResearchAgent(provider="deepseek")
 
 # Force OpenRouter
 agent = ResearchAgent(provider="openrouter")
+
+# Force Gemini
+agent = ResearchAgent(provider="gemini")
 ```
 
 **API Request:**
@@ -100,6 +113,12 @@ clarifier = QueryClarifier(
 clarifier = QueryClarifier(
     provider="openrouter",
     model_name="google/gemini-pro"
+)
+
+# Use Gemini directly
+clarifier = QueryClarifier(
+    provider="gemini",
+    model_name="gemini-2.5-flash"
 )
 ```
 

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -9,7 +9,7 @@ pip install -r requirements.txt
 
 ### Step 2: Set Up Your API Key
 
-**Choose your LLM provider** (OpenAI, DeepSeek, or OpenRouter):
+**Choose your LLM provider** (OpenAI, DeepSeek, OpenRouter, or Gemini):
 
 1. Copy the example environment file:
    ```bash
@@ -34,6 +34,12 @@ pip install -r requirements.txt
    ```
    LLM_PROVIDER=openrouter
    OPENROUTER_API_KEY=sk-or-your-openrouter-key-here
+   ```
+
+   **Option D: Using Gemini**
+   ```
+   LLM_PROVIDER=gemini
+   GOOGLE_API_KEY=your-google-api-key-here
    ```
 
 ### Step 3: Run the Agent

--- a/README.md
+++ b/README.md
@@ -19,12 +19,12 @@ pip install -r requirements.txt
 
 2. **Configure Environment Variables**
 
-Choose your LLM provider (OpenAI, DeepSeek, or OpenRouter):
+Choose your LLM provider (OpenAI, DeepSeek, OpenRouter, or Gemini):
 
 ```bash
 cp .env.example .env
 # Edit .env and set:
-# - LLM_PROVIDER=openai, deepseek, or openrouter
+# - LLM_PROVIDER=openai, deepseek, openrouter, or gemini
 # - Add the corresponding API key
 ```
 
@@ -44,6 +44,12 @@ DEEPSEEK_API_KEY=your-key-here
 ```
 LLM_PROVIDER=openrouter
 OPENROUTER_API_KEY=sk-or-your-key-here
+```
+
+**For Gemini:**
+```
+LLM_PROVIDER=gemini
+GOOGLE_API_KEY=your-google-api-key-here
 ```
 
 3. **Run the Agent**
@@ -100,5 +106,5 @@ The agent creates markdown files in the `results/` directory with content like:
 ## Requirements
 
 - Python 3.9+
-- API key for one of: OpenAI, DeepSeek, or OpenRouter
+- API key for one of: OpenAI, DeepSeek, OpenRouter, or Gemini
 - Scholarly - for Google Scholar Feed Crawlng

--- a/agent.py
+++ b/agent.py
@@ -17,7 +17,7 @@ class ResearchAgent:
         
         Args:
             max_papers: Maximum number of papers to fetch
-            provider: LLM provider ("openai" or "deepseek"). If None, reads from env
+            provider: LLM provider ("openai", "deepseek", "openrouter", "gemini"). If None, reads from env
         """
         self.query_clarifier = QueryClarifier(provider=provider)
         self.scholar_fetcher = ScholarFetcher(max_results=max_papers)

--- a/api_server.py
+++ b/api_server.py
@@ -17,7 +17,7 @@ class ResearchRequest(BaseModel):
     """Request model for research queries."""
     query: str = Field(..., description="The research query to process", min_length=3)
     max_papers: Optional[int] = Field(default=10, description="Maximum number of papers to fetch", ge=1, le=50)
-    provider: Optional[str] = Field(default=None, description="LLM provider: 'openai', 'deepseek', or 'openrouter' (defaults to env LLM_PROVIDER)")
+    provider: Optional[str] = Field(default=None, description="LLM provider: 'openai', 'deepseek', 'openrouter', or 'gemini' (defaults to env LLM_PROVIDER)")
 
 
 class ResearchResponse(BaseModel):

--- a/llm_provider.py
+++ b/llm_provider.py
@@ -26,7 +26,7 @@ class LLMProviderProcessor:
     """
     Centralized processor for LLM provider configurations.
     
-    Handles configuration for OpenAI, DeepSeek, and OpenRouter providers.
+    Handles configuration for OpenAI, DeepSeek, OpenRouter, and Gemini providers.
     Reads from environment variables and provides a unified interface.
     """
     
@@ -46,6 +46,11 @@ class LLMProviderProcessor:
             "model_name": "alibaba/tongyi-deepresearch-30b-a3b:free",
             "base_url": "https://openrouter.ai/api/v1",
             "api_key_env": "OPENROUTER_API_KEY"
+        },
+        "gemini": {
+            "model_name": "gemini-2.5-flash",
+            "base_url": "https://generativelanguage.googleapis.com/v1beta/openai/",
+            "api_key_env": "GOOGLE_API_KEY"
         }
     }
     
@@ -60,7 +65,7 @@ class LLMProviderProcessor:
         Get LLM configuration for the specified provider.
         
         Args:
-            provider: Provider name ("openai", "deepseek", "openrouter").
+            provider: Provider name ("openai", "deepseek", "openrouter", "gemini").
                      If None, reads from LLM_PROVIDER env variable.
             model_name: Model name to use. If None, uses provider default.
             temperature: Temperature for generation.
@@ -134,7 +139,7 @@ if __name__ == "__main__":
     print(f"Available providers: {LLMProviderProcessor.get_available_providers()}\n")
     
     # Test each provider (will fail if API keys not set)
-    for provider in ["openai", "deepseek", "openrouter"]:
+    for provider in ["openai", "deepseek", "openrouter", "gemini"]:
         try:
             config = LLMProviderProcessor.get_config(provider=provider)
             print(f"✓ {provider.upper()} Configuration:")

--- a/query_clarifier.py
+++ b/query_clarifier.py
@@ -18,7 +18,7 @@ class QueryClarifier:
         Initialize the query clarifier.
         
         Args:
-            provider: LLM provider ("openai", "deepseek", "openrouter").
+            provider: LLM provider ("openai", "deepseek", "openrouter", "gemini").
                      If None, reads from LLM_PROVIDER env variable.
             model_name: Model name to use (auto-selected based on provider if None).
             temperature: Temperature for generation.
@@ -37,7 +37,7 @@ class QueryClarifier:
             "api_key": self.config.api_key
         }
         
-        # Add base_url if specified (for DeepSeek and OpenRouter)
+        # Add base_url if specified (for DeepSeek, OpenRouter, Gemini)
         if self.config.base_url:
             llm_kwargs["base_url"] = self.config.base_url
         


### PR DESCRIPTION
- Add Gemini to PROVIDER_DEFAULTS with OpenAI-compatible endpoint
- Use Google's generativelanguage API (OpenAI-compatible)
- Update documentation (README, QUICKSTART, PROVIDER_GUIDE, FEATURES)
- Update .env.example with GOOGLE_API_KEY
- No new dependencies required